### PR TITLE
feat: Unified options data model (#12)

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod error;
+pub mod types;
 
 pub use config::AppConfig;
 pub use error::AppError;

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -1,0 +1,206 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VenueId {
+    Deribit,
+    Derive,
+    Aevo,
+    Premia,
+    Stryke,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OptionType {
+    Call,
+    Put,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OptionStyle {
+    European,
+    American,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TradeSide {
+    Buy,
+    Sell,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Instrument {
+    pub underlying: String,
+    pub strike: f64,
+    pub expiry: String,
+    pub option_type: OptionType,
+    pub style: OptionStyle,
+    pub venue: VenueId,
+    pub venue_symbol: String,
+}
+
+impl Instrument {
+    pub fn from_clob_symbol(venue: VenueId, symbol: &str) -> Option<Self> {
+        let mut parts = symbol.split('-');
+        let underlying = parts.next()?.trim().to_uppercase();
+        let expiry = parts.next()?.trim().to_uppercase();
+        let strike = parts.next()?.trim().parse::<f64>().ok()?;
+        let option_type = match parts.next()?.trim().to_uppercase().as_str() {
+            "C" => OptionType::Call,
+            "P" => OptionType::Put,
+            _ => return None,
+        };
+
+        Some(Self {
+            underlying,
+            strike,
+            expiry,
+            option_type,
+            style: OptionStyle::European,
+            venue,
+            venue_symbol: symbol.to_string(),
+        })
+    }
+}
+
+pub fn match_instrument(a: &Instrument, b: &Instrument) -> bool {
+    a.underlying == b.underlying
+        && a.expiry == b.expiry
+        && (a.strike - b.strike).abs() < f64::EPSILON
+        && a.option_type == b.option_type
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Greeks {
+    pub delta: Option<f64>,
+    pub gamma: Option<f64>,
+    pub theta: Option<f64>,
+    pub vega: Option<f64>,
+    pub rho: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Ticker {
+    pub instrument: Instrument,
+    pub venue: VenueId,
+    pub bid: Option<f64>,
+    pub ask: Option<f64>,
+    pub mid: Option<f64>,
+    pub mark_price: Option<f64>,
+    pub index_price: Option<f64>,
+    pub iv: Option<f64>,
+    pub bid_iv: Option<f64>,
+    pub ask_iv: Option<f64>,
+    pub greeks: Greeks,
+    pub timestamp_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OrderBookLevel {
+    pub price: f64,
+    pub size: f64,
+    pub iv: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OrderBook {
+    pub instrument: Instrument,
+    pub venue: VenueId,
+    pub bids: Vec<OrderBookLevel>,
+    pub asks: Vec<OrderBookLevel>,
+    pub timestamp_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Trade {
+    pub instrument: Instrument,
+    pub venue: VenueId,
+    pub price: f64,
+    pub size: f64,
+    pub side: TradeSide,
+    pub timestamp_ms: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeribitTicker {
+    pub instrument_name: String,
+    pub best_bid_price: Option<f64>,
+    pub best_ask_price: Option<f64>,
+    pub mark_price: Option<f64>,
+    pub index_price: Option<f64>,
+    pub iv: Option<f64>,
+    pub bid_iv: Option<f64>,
+    pub ask_iv: Option<f64>,
+    pub greeks: Greeks,
+    pub timestamp_ms: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeriveTicker {
+    pub instrument_name: String,
+    pub best_bid_price: Option<f64>,
+    pub best_ask_price: Option<f64>,
+    pub mark_price: Option<f64>,
+    pub index_price: Option<f64>,
+    pub option_iv: Option<f64>,
+    pub bid_iv: Option<f64>,
+    pub ask_iv: Option<f64>,
+    pub greeks: Greeks,
+    pub timestamp_ms: i64,
+}
+
+impl TryFrom<DeribitTicker> for Ticker {
+    type Error = &'static str;
+
+    fn try_from(value: DeribitTicker) -> Result<Self, Self::Error> {
+        let instrument =
+            Instrument::from_clob_symbol(VenueId::Deribit, &value.instrument_name)
+                .ok_or("invalid deribit instrument")?;
+        let mid = match (value.best_bid_price, value.best_ask_price) {
+            (Some(bid), Some(ask)) => Some((bid + ask) / 2.0),
+            _ => None,
+        };
+
+        Ok(Self {
+            instrument,
+            venue: VenueId::Deribit,
+            bid: value.best_bid_price,
+            ask: value.best_ask_price,
+            mid,
+            mark_price: value.mark_price,
+            index_price: value.index_price,
+            iv: value.iv,
+            bid_iv: value.bid_iv,
+            ask_iv: value.ask_iv,
+            greeks: value.greeks,
+            timestamp_ms: value.timestamp_ms,
+        })
+    }
+}
+
+impl TryFrom<DeriveTicker> for Ticker {
+    type Error = &'static str;
+
+    fn try_from(value: DeriveTicker) -> Result<Self, Self::Error> {
+        let instrument = Instrument::from_clob_symbol(VenueId::Derive, &value.instrument_name)
+            .ok_or("invalid derive instrument")?;
+        let mid = match (value.best_bid_price, value.best_ask_price) {
+            (Some(bid), Some(ask)) => Some((bid + ask) / 2.0),
+            _ => None,
+        };
+
+        Ok(Self {
+            instrument,
+            venue: VenueId::Derive,
+            bid: value.best_bid_price,
+            ask: value.best_ask_price,
+            mid,
+            mark_price: value.mark_price,
+            index_price: value.index_price,
+            iv: value.option_iv,
+            bid_iv: value.bid_iv,
+            ask_iv: value.ask_iv,
+            greeks: value.greeks,
+            timestamp_ms: value.timestamp_ms,
+        })
+    }
+}

--- a/crates/common/tests/types_normalization.rs
+++ b/crates/common/tests/types_normalization.rs
@@ -1,0 +1,70 @@
+use common::types::{match_instrument, OptionType, VenueId};
+
+#[test]
+fn parses_clob_symbol_into_instrument() {
+    let instrument = common::types::Instrument::from_clob_symbol(
+        VenueId::Deribit,
+        "BTC-27DEC24-50000-C",
+    )
+    .expect("instrument should parse");
+
+    assert_eq!(instrument.underlying, "BTC");
+    assert_eq!(instrument.strike, 50_000.0);
+    assert_eq!(instrument.option_type, OptionType::Call);
+}
+
+#[test]
+fn matches_instruments_across_venues() {
+    let a = common::types::Instrument::from_clob_symbol(
+        VenueId::Deribit,
+        "ETH-28MAR26-3000-C",
+    )
+    .unwrap();
+    let b = common::types::Instrument::from_clob_symbol(
+        VenueId::Derive,
+        "ETH-28MAR26-3000-C",
+    )
+    .unwrap();
+
+    assert!(match_instrument(&a, &b));
+}
+
+#[test]
+fn converts_deribit_ticker_to_unified_ticker() {
+    let raw = common::types::DeribitTicker {
+        instrument_name: "BTC-27DEC24-50000-C".to_string(),
+        best_bid_price: Some(1000.0),
+        best_ask_price: Some(1010.0),
+        mark_price: Some(1005.0),
+        index_price: Some(50_000.0),
+        iv: Some(0.55),
+        bid_iv: Some(0.54),
+        ask_iv: Some(0.56),
+        greeks: common::types::Greeks::default(),
+        timestamp_ms: 1,
+    };
+
+    let ticker = common::types::Ticker::try_from(raw).expect("conversion should work");
+    assert_eq!(ticker.venue, VenueId::Deribit);
+    assert_eq!(ticker.mid, Some(1005.0));
+}
+
+#[test]
+fn converts_derive_ticker_to_unified_ticker() {
+    let raw = common::types::DeriveTicker {
+        instrument_name: "ETH-28MAR26-3000-C".to_string(),
+        best_bid_price: Some(220.0),
+        best_ask_price: Some(230.0),
+        mark_price: Some(225.0),
+        index_price: Some(2_950.0),
+        option_iv: Some(0.60),
+        bid_iv: Some(0.59),
+        ask_iv: Some(0.61),
+        greeks: common::types::Greeks::default(),
+        timestamp_ms: 1,
+    };
+
+    let ticker = common::types::Ticker::try_from(raw).expect("conversion should work");
+    assert_eq!(ticker.venue, VenueId::Derive);
+    assert_eq!(ticker.iv, Some(0.60));
+}


### PR DESCRIPTION
Implements issue #12.\n\n- Adds unified data model types (Instrument, Ticker, OrderBook, Trade, VenueId)\n- Adds normalization helper for CLOB symbols\n- Adds Deribit/Derive raw ticker adapters into unified ticker type\n- Adds unit tests for normalization and matching\n\nCloses #12