### PR TITLE
feat: Derive connector foundation (#15)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,14 +106,20 @@ dependencies = [
 name = "connector-deribit"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "common",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "connector-derive"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "common",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/connector-derive/Cargo.toml
+++ b/crates/connector-derive/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/connector-derive/src/lib.rs
+++ b/crates/connector-derive/src/lib.rs
@@ -1,3 +1,50 @@
-pub fn crate_name() -> &'static str {
-    "connector-derive"
+use anyhow::{anyhow, Result};
+use common::types::{DeriveTicker, Greeks, Ticker};
+use serde_json::Value;
+
+pub const DERIVE_PROD_WS: &str = "wss://api.lyra.finance/ws";
+pub const DERIVE_TESTNET_WS: &str = "wss://api-demo.lyra.finance/ws";
+
+pub fn build_json_rpc_request(id: u64, method: &str, params: Value) -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params,
+    })
+}
+
+pub fn reconnect_delay_ms(attempt: u32) -> u64 {
+    let value = 500_u64.saturating_mul(2_u64.saturating_pow(attempt));
+    value.min(30_000)
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct RawDeriveTicker {
+    pub instrument_name: String,
+    pub best_bid_price: Option<f64>,
+    pub best_ask_price: Option<f64>,
+    pub mark_price: Option<f64>,
+    pub index_price: Option<f64>,
+    pub option_iv: Option<f64>,
+    pub bid_iv: Option<f64>,
+    pub ask_iv: Option<f64>,
+    pub timestamp_ms: i64,
+}
+
+pub fn to_unified_ticker(raw: RawDeriveTicker) -> Result<Ticker> {
+    let ticker = DeriveTicker {
+        instrument_name: raw.instrument_name,
+        best_bid_price: raw.best_bid_price,
+        best_ask_price: raw.best_ask_price,
+        mark_price: raw.mark_price,
+        index_price: raw.index_price,
+        option_iv: raw.option_iv,
+        bid_iv: raw.bid_iv,
+        ask_iv: raw.ask_iv,
+        greeks: Greeks::default(),
+        timestamp_ms: raw.timestamp_ms,
+    };
+
+    Ticker::try_from(ticker).map_err(|err| anyhow!(err))
 }

--- a/crates/connector-derive/tests/derive_connector.rs
+++ b/crates/connector-derive/tests/derive_connector.rs
@@ -1,0 +1,36 @@
+use connector_derive::{build_json_rpc_request, reconnect_delay_ms, to_unified_ticker, RawDeriveTicker};
+use common::types::VenueId;
+
+#[test]
+fn builds_json_rpc_payload() {
+    let payload = build_json_rpc_request(1, "public/get_ticker", serde_json::json!({"instrument_name": "ETH-28MAR26-3000-C"}));
+    assert_eq!(payload["jsonrpc"], "2.0");
+    assert_eq!(payload["id"], 1);
+    assert_eq!(payload["method"], "public/get_ticker");
+}
+
+#[test]
+fn converts_derive_raw_ticker() {
+    let raw = RawDeriveTicker {
+        instrument_name: "ETH-28MAR26-3000-C".to_string(),
+        best_bid_price: Some(220.0),
+        best_ask_price: Some(230.0),
+        mark_price: Some(225.0),
+        index_price: Some(2950.0),
+        option_iv: Some(0.60),
+        bid_iv: Some(0.59),
+        ask_iv: Some(0.61),
+        timestamp_ms: 123,
+    };
+
+    let ticker = to_unified_ticker(raw).expect("conversion works");
+    assert_eq!(ticker.venue, VenueId::Derive);
+    assert_eq!(ticker.iv, Some(0.60));
+}
+
+#[test]
+fn reconnect_backoff_caps() {
+    assert_eq!(reconnect_delay_ms(0), 500);
+    assert_eq!(reconnect_delay_ms(1), 1000);
+    assert_eq!(reconnect_delay_ms(10), 30_000);
+}


### PR DESCRIPTION
Implements issue #15.\n\n- Adds JSON-RPC 2.0 payload builder\n- Adds reconnect strategy helper\n- Adds raw Derive ticker adapter to unified model\n- Adds unit tests for payload/conversion/backoff\n\nCloses #15