### PR TITLE
feat: Cross-CLOB IV scanner (#16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ name = "arb-scanner"
 version = "0.1.0"
 dependencies = [
  "common",
+ "serde",
 ]
 
 [[package]]

--- a/crates/arb-scanner/Cargo.toml
+++ b/crates/arb-scanner/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
+serde = { version = "1", features = ["derive"] }

--- a/crates/arb-scanner/src/lib.rs
+++ b/crates/arb-scanner/src/lib.rs
@@ -1,3 +1,113 @@
-pub fn crate_name() -> &'static str {
-    "arb-scanner"
+use common::types::{match_instrument, Ticker, VenueId};
+
+#[derive(Debug, Clone)]
+pub struct ScannerConfig {
+    pub min_expected_pnl: f64,
+    pub fee_model: FeeModel,
+    pub slippage_bps: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeeModel {
+    pub deribit_taker_rate: f64,
+    pub derive_taker_rate: f64,
+}
+
+impl Default for FeeModel {
+    fn default() -> Self {
+        Self {
+            deribit_taker_rate: 0.0003,
+            derive_taker_rate: 0.0005,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ArbSignal {
+    pub instrument_symbol: String,
+    pub buy_venue: VenueId,
+    pub sell_venue: VenueId,
+    pub iv_spread: f64,
+    pub estimated_pnl: f64,
+    pub timestamp_ms: i64,
+}
+
+pub fn scan_cross_clob_opportunities(tickers: &[Ticker], config: &ScannerConfig) -> Vec<ArbSignal> {
+    let mut signals = Vec::new();
+
+    for (index, buy) in tickers.iter().enumerate() {
+        for sell in tickers.iter().skip(index + 1) {
+            if buy.venue == sell.venue || !match_instrument(&buy.instrument, &sell.instrument) {
+                continue;
+            }
+
+            if let Some(signal) = build_signal(buy, sell, config) {
+                signals.push(signal);
+            }
+            if let Some(signal) = build_signal(sell, buy, config) {
+                signals.push(signal);
+            }
+        }
+    }
+
+    signals
+}
+
+pub fn replay_backtest(frames: Vec<Vec<Ticker>>, config: &ScannerConfig) -> Vec<ArbSignal> {
+    let mut all = Vec::new();
+    for frame in frames {
+        all.extend(scan_cross_clob_opportunities(&frame, config));
+    }
+    all
+}
+
+fn build_signal(buy: &Ticker, sell: &Ticker, config: &ScannerConfig) -> Option<ArbSignal> {
+    let buy_ask_iv = buy.ask_iv?;
+    let sell_bid_iv = sell.bid_iv?;
+    if buy_ask_iv >= sell_bid_iv {
+        return None;
+    }
+
+    let iv_spread = sell_bid_iv - buy_ask_iv;
+    let vega = buy.greeks.vega.or(sell.greeks.vega).unwrap_or(0.0);
+    let gross = iv_spread * vega;
+    let fees = estimated_fees(buy, sell, &config.fee_model);
+    let slippage = estimated_slippage(buy, sell, config.slippage_bps);
+    let estimated_pnl = gross - fees - slippage;
+
+    if estimated_pnl <= config.min_expected_pnl {
+        return None;
+    }
+
+    Some(ArbSignal {
+        instrument_symbol: buy.instrument.venue_symbol.clone(),
+        buy_venue: buy.venue,
+        sell_venue: sell.venue,
+        iv_spread,
+        estimated_pnl,
+        timestamp_ms: buy.timestamp_ms.min(sell.timestamp_ms),
+    })
+}
+
+fn estimated_fees(buy: &Ticker, sell: &Ticker, fee_model: &FeeModel) -> f64 {
+    let buy_notional = buy.ask.unwrap_or(0.0);
+    let sell_notional = sell.bid.unwrap_or(0.0);
+
+    let buy_fee = match buy.venue {
+        VenueId::Deribit => buy_notional * fee_model.deribit_taker_rate,
+        VenueId::Derive => buy_notional * fee_model.derive_taker_rate,
+        _ => buy_notional * fee_model.derive_taker_rate,
+    };
+    let sell_fee = match sell.venue {
+        VenueId::Deribit => sell_notional * fee_model.deribit_taker_rate,
+        VenueId::Derive => sell_notional * fee_model.derive_taker_rate,
+        _ => sell_notional * fee_model.derive_taker_rate,
+    };
+
+    buy_fee + sell_fee
+}
+
+fn estimated_slippage(buy: &Ticker, sell: &Ticker, bps: f64) -> f64 {
+    let notional = buy.ask.unwrap_or(0.0) + sell.bid.unwrap_or(0.0);
+    notional * bps / 10_000.0
 }

--- a/crates/arb-scanner/tests/cross_clob.rs
+++ b/crates/arb-scanner/tests/cross_clob.rs
@@ -1,0 +1,64 @@
+use arb_scanner::{scan_cross_clob_opportunities, FeeModel, ScannerConfig};
+use common::types::{Greeks, Instrument, OptionStyle, OptionType, Ticker, VenueId};
+
+fn sample_ticker(venue: VenueId, bid_iv: f64, ask_iv: f64, vega: f64) -> Ticker {
+    Ticker {
+        instrument: Instrument {
+            underlying: "BTC".to_string(),
+            strike: 50_000.0,
+            expiry: "27DEC24".to_string(),
+            option_type: OptionType::Call,
+            style: OptionStyle::European,
+            venue,
+            venue_symbol: "BTC-27DEC24-50000-C".to_string(),
+        },
+        venue,
+        bid: Some(1000.0),
+        ask: Some(1010.0),
+        mid: Some(1005.0),
+        mark_price: Some(1005.0),
+        index_price: Some(50_000.0),
+        iv: Some((bid_iv + ask_iv) / 2.0),
+        bid_iv: Some(bid_iv),
+        ask_iv: Some(ask_iv),
+        greeks: Greeks {
+            delta: Some(0.5),
+            gamma: Some(0.0),
+            theta: Some(0.0),
+            vega: Some(vega),
+            rho: Some(0.0),
+        },
+        timestamp_ms: 1,
+    }
+}
+
+#[test]
+fn finds_cross_clob_signal_when_spread_beats_fees() {
+    let deribit = sample_ticker(VenueId::Deribit, 0.62, 0.63, 120.0);
+    let derive = sample_ticker(VenueId::Derive, 0.70, 0.71, 120.0);
+
+    let config = ScannerConfig {
+        min_expected_pnl: 1.0,
+        fee_model: FeeModel::default(),
+        slippage_bps: 1.0,
+    };
+
+    let signals = scan_cross_clob_opportunities(&[deribit, derive], &config);
+    assert_eq!(signals.len(), 1);
+    assert!(signals[0].estimated_pnl > 0.0);
+}
+
+#[test]
+fn ignores_pairs_when_spread_too_small() {
+    let deribit = sample_ticker(VenueId::Deribit, 0.60, 0.61, 100.0);
+    let derive = sample_ticker(VenueId::Derive, 0.61, 0.62, 100.0);
+
+    let config = ScannerConfig {
+        min_expected_pnl: 10.0,
+        fee_model: FeeModel::default(),
+        slippage_bps: 5.0,
+    };
+
+    let signals = scan_cross_clob_opportunities(&[deribit, derive], &config);
+    assert!(signals.is_empty());
+}


### PR DESCRIPTION
Implements issue #16.\n\n- Adds instrument-pair IV comparison engine\n- Adds fee + slippage aware expected PnL estimator\n- Adds structured signal output\n- Adds frame replay helper for backtest mode\n- Adds unit tests with mock market data\n\nCloses #16