### PR TITLE
feat: Derive data collector helpers (#6)

### DIFF
--- a/crates/connector-derive/src/lib.rs
+++ b/crates/connector-derive/src/lib.rs
@@ -4,6 +4,8 @@ use serde_json::Value;
 
 pub const DERIVE_PROD_WS: &str = "wss://api.lyra.finance/ws";
 pub const DERIVE_TESTNET_WS: &str = "wss://api-demo.lyra.finance/ws";
+pub const DERIVE_PROD_REST: &str = "https://api.lyra.finance";
+pub const DERIVE_TESTNET_REST: &str = "https://api-demo.lyra.finance";
 
 pub fn build_json_rpc_request(id: u64, method: &str, params: Value) -> Value {
     serde_json::json!({
@@ -12,6 +14,42 @@ pub fn build_json_rpc_request(id: u64, method: &str, params: Value) -> Value {
         "method": method,
         "params": params,
     })
+}
+
+pub fn build_get_all_instruments_request(id: u64, base_currency: &str) -> Value {
+    build_json_rpc_request(
+        id,
+        "public/get_all_instruments",
+        serde_json::json!({ "base_currency": base_currency }),
+    )
+}
+
+pub fn build_get_ticker_request(id: u64, instrument_name: &str) -> Value {
+    build_json_rpc_request(
+        id,
+        "public/get_ticker",
+        serde_json::json!({ "instrument_name": instrument_name }),
+    )
+}
+
+pub fn build_session_key_auth_request(id: u64, session_key: &str) -> Value {
+    build_json_rpc_request(
+        id,
+        "private/login",
+        serde_json::json!({
+            "grant_type": "session_key",
+            "session_key": session_key,
+        }),
+    )
+}
+
+pub fn parse_instrument_symbols(response: &Value) -> Vec<String> {
+    response["result"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item["instrument_name"].as_str().map(ToString::to_string))
+        .collect()
 }
 
 pub fn reconnect_delay_ms(attempt: u32) -> u64 {

--- a/crates/connector-derive/tests/derive_collector_workflow.rs
+++ b/crates/connector-derive/tests/derive_collector_workflow.rs
@@ -1,0 +1,38 @@
+use connector_derive::{
+    build_get_all_instruments_request, build_get_ticker_request, build_session_key_auth_request,
+    parse_instrument_symbols,
+};
+
+#[test]
+fn builds_get_all_instruments_request() {
+    let req = build_get_all_instruments_request(7, "ETH");
+    assert_eq!(req["method"], "public/get_all_instruments");
+    assert_eq!(req["params"]["base_currency"], "ETH");
+}
+
+#[test]
+fn builds_session_key_auth_request() {
+    let req = build_session_key_auth_request(9, "session-key");
+    assert_eq!(req["method"], "private/login");
+    assert_eq!(req["params"]["grant_type"], "session_key");
+}
+
+#[test]
+fn parses_instrument_names_from_jsonrpc_result() {
+    let sample = serde_json::json!({
+        "result": [
+            {"instrument_name": "ETH-28MAR26-3000-C"},
+            {"instrument_name": "ETH-28MAR26-3000-P"}
+        ]
+    });
+
+    let names = parse_instrument_symbols(&sample);
+    assert_eq!(names.len(), 2);
+}
+
+#[test]
+fn builds_get_ticker_request() {
+    let req = build_get_ticker_request(10, "ETH-28MAR26-3000-C");
+    assert_eq!(req["method"], "public/get_ticker");
+    assert_eq!(req["params"]["instrument_name"], "ETH-28MAR26-3000-C");
+}


### PR DESCRIPTION
Implements issue #6.\n\n- Adds JSON-RPC request builders for instrument/ticker/auth\n- Adds instrument list parser for JSON-RPC responses\n- Adds prod/testnet endpoint constants\n- Adds unit tests for request and parsing workflow\n\nCloses #6