### PR TITLE
feat: Aevo data collector foundation (#7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,9 @@ dependencies = [
 name = "connector-aevo"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "common",
+ "serde",
 ]
 
 [[package]]

--- a/crates/connector-aevo/Cargo.toml
+++ b/crates/connector-aevo/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }

--- a/crates/connector-aevo/src/lib.rs
+++ b/crates/connector-aevo/src/lib.rs
@@ -1,3 +1,85 @@
-pub fn crate_name() -> &'static str {
-    "connector-aevo"
+use std::collections::BTreeMap;
+
+use anyhow::{anyhow, Result};
+
+pub const AEVO_REST_BASE: &str = "https://api.aevo.xyz";
+pub const AEVO_WS_BASE: &str = "wss://ws.aevo.xyz";
+
+pub fn build_markets_url(asset: &str, instrument_type: &str) -> String {
+    format!(
+        "{AEVO_REST_BASE}/markets?asset={asset}&instrument_type={instrument_type}"
+    )
+}
+
+pub fn orderbook_channel(instrument: &str) -> String {
+    format!("orderbook-100ms:{instrument}")
+}
+
+pub fn trades_channel(asset: &str) -> String {
+    format!("trades:{asset}")
+}
+
+#[derive(Debug, Clone)]
+pub struct AevoLocalOrderBook {
+    pub bids: BTreeMap<i64, f64>,
+    pub asks: BTreeMap<i64, f64>,
+}
+
+impl AevoLocalOrderBook {
+    pub fn new() -> Self {
+        Self {
+            bids: BTreeMap::new(),
+            asks: BTreeMap::new(),
+        }
+    }
+
+    pub fn apply_snapshot(&mut self, bids: Vec<(f64, f64)>, asks: Vec<(f64, f64)>) {
+        self.bids.clear();
+        self.asks.clear();
+        update_side(&mut self.bids, bids);
+        update_side(&mut self.asks, asks);
+    }
+
+    pub fn apply_delta(
+        &mut self,
+        bids: Vec<(f64, f64)>,
+        asks: Vec<(f64, f64)>,
+        expected_checksum: u64,
+    ) -> Result<()> {
+        update_side(&mut self.bids, bids);
+        update_side(&mut self.asks, asks);
+
+        let current = compute_orderbook_checksum(self);
+        if current != expected_checksum {
+            return Err(anyhow!(
+                "checksum mismatch: expected {expected_checksum}, got {current}"
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+pub fn compute_orderbook_checksum(book: &AevoLocalOrderBook) -> u64 {
+    let mut value = 0_u64;
+
+    for (price, size) in book.bids.iter().take(5) {
+        value = value.wrapping_add(*price as u64).wrapping_add(*size as u64);
+    }
+    for (price, size) in book.asks.iter().take(5) {
+        value = value.wrapping_add(*price as u64).wrapping_add(*size as u64);
+    }
+
+    value
+}
+
+fn update_side(side: &mut BTreeMap<i64, f64>, levels: Vec<(f64, f64)>) {
+    for (price, size) in levels {
+        let key = (price * 10000.0).round() as i64;
+        if size <= 0.0 {
+            side.remove(&key);
+        } else {
+            side.insert(key, size);
+        }
+    }
 }

--- a/crates/connector-aevo/tests/aevo_collector.rs
+++ b/crates/connector-aevo/tests/aevo_collector.rs
@@ -1,0 +1,38 @@
+use connector_aevo::{
+    build_markets_url, compute_orderbook_checksum, orderbook_channel, trades_channel,
+    AevoLocalOrderBook,
+};
+
+#[test]
+fn builds_markets_endpoint() {
+    let url = build_markets_url("ETH", "OPTION");
+    assert_eq!(
+        url,
+        "https://api.aevo.xyz/markets?asset=ETH&instrument_type=OPTION"
+    );
+}
+
+#[test]
+fn builds_ws_channels() {
+    assert_eq!(
+        orderbook_channel("ETH-28MAR25-2000-C"),
+        "orderbook-100ms:ETH-28MAR25-2000-C"
+    );
+    assert_eq!(trades_channel("ETH"), "trades:ETH");
+}
+
+#[test]
+fn validates_checksum_after_delta() {
+    let mut book = AevoLocalOrderBook::new();
+    book.apply_snapshot(vec![(100.0, 1.0)], vec![(101.0, 2.0)]);
+
+    let mut expected_book = book.clone();
+    expected_book
+        .apply_delta(vec![(100.0, 2.0)], vec![], u64::MAX)
+        .ok();
+    let expected_checksum = compute_orderbook_checksum(&expected_book);
+
+    assert!(book
+        .apply_delta(vec![(100.0, 2.0)], vec![], expected_checksum)
+        .is_ok());
+}


### PR DESCRIPTION
Implements issue #7.\n\n- Adds REST markets endpoint builder\n- Adds websocket channel helpers for orderbook/trades\n- Adds local orderbook with snapshot+delta handling\n- Adds checksum validation utility\n- Adds unit tests for collector primitives\n\nCloses #7