### PR TITLE
feat: CeFi vs AMM vol lag scanner (#18)

### DIFF
--- a/crates/arb-scanner/src/lib.rs
+++ b/crates/arb-scanner/src/lib.rs
@@ -213,3 +213,49 @@ fn estimated_slippage(buy: &Ticker, sell: &Ticker, bps: f64) -> f64 {
 fn year_fraction_from_expiry_code(_expiry: &str) -> f64 {
     30.0 / 365.0
 }
+
+#[derive(Debug, Clone)]
+pub struct VolLagSignal {
+    pub instrument_symbol: String,
+    pub deribit_iv: f64,
+    pub premia_iv: f64,
+    pub oracle_iv: Option<f64>,
+    pub iv_gap: f64,
+    pub timestamp_ms: i64,
+}
+
+pub fn scan_cefi_amm_vol_lag(
+    deribit_tickers: &[Ticker],
+    premia_tickers: &[Ticker],
+    oracle_ivs: &HashMap<String, f64>,
+    min_iv_gap: f64,
+) -> Vec<VolLagSignal> {
+    let mut out = Vec::new();
+
+    for deribit in deribit_tickers {
+        for premia in premia_tickers {
+            if !match_instrument(&deribit.instrument, &premia.instrument) {
+                continue;
+            }
+
+            let deribit_iv = deribit.iv.or(deribit.ask_iv).unwrap_or(0.0);
+            let premia_iv = premia.iv.or(premia.ask_iv).unwrap_or(0.0);
+            let iv_gap = deribit_iv - premia_iv;
+            if iv_gap < min_iv_gap {
+                continue;
+            }
+
+            let oracle_iv = oracle_ivs.get(&deribit.instrument.venue_symbol).copied();
+            out.push(VolLagSignal {
+                instrument_symbol: deribit.instrument.venue_symbol.clone(),
+                deribit_iv,
+                premia_iv,
+                oracle_iv,
+                iv_gap,
+                timestamp_ms: deribit.timestamp_ms.min(premia.timestamp_ms),
+            });
+        }
+    }
+
+    out
+}

--- a/crates/arb-scanner/tests/vol_lag.rs
+++ b/crates/arb-scanner/tests/vol_lag.rs
@@ -1,0 +1,47 @@
+use std::collections::HashMap;
+
+use arb_scanner::scan_cefi_amm_vol_lag;
+use common::types::{Greeks, Instrument, OptionStyle, OptionType, Ticker, VenueId};
+
+fn mk(venue: VenueId, bid_iv: f64, ask_iv: f64) -> Ticker {
+    Ticker {
+        instrument: Instrument {
+            underlying: "ETH".into(),
+            strike: 3000.0,
+            expiry: "28MAR26".into(),
+            option_type: OptionType::Call,
+            style: OptionStyle::European,
+            venue,
+            venue_symbol: "ETH-28MAR26-3000-C".into(),
+        },
+        venue,
+        bid: Some(220.0),
+        ask: Some(225.0),
+        mid: Some(222.5),
+        mark_price: Some(222.5),
+        index_price: Some(2950.0),
+        iv: Some((bid_iv + ask_iv) / 2.0),
+        bid_iv: Some(bid_iv),
+        ask_iv: Some(ask_iv),
+        greeks: Greeks {
+            delta: Some(0.5),
+            gamma: Some(0.0),
+            theta: Some(0.0),
+            vega: Some(120.0),
+            rho: Some(0.0),
+        },
+        timestamp_ms: 1,
+    }
+}
+
+#[test]
+fn detects_vol_lag_when_deribit_spikes_above_premia() {
+    let deribit = mk(VenueId::Deribit, 0.90, 0.92);
+    let premia = mk(VenueId::Premia, 0.62, 0.64);
+    let mut oracle = HashMap::new();
+    oracle.insert("ETH-28MAR26-3000-C".to_string(), 0.63);
+
+    let signals = scan_cefi_amm_vol_lag(&[deribit], &[premia], &oracle, 0.1);
+    assert_eq!(signals.len(), 1);
+    assert!(signals[0].iv_gap > 0.2);
+}


### PR DESCRIPTION
Implements issue #18.\n\n- Adds Deribit vs Premia IV lag detection\n- Adds oracle-IV context in emitted lag signals\n- Adds unit test for lag detection behavior\n\nCloses #18