### PR TITLE
feat: Put-call parity cross-venue scanner (#19)

### DIFF
--- a/crates/arb-scanner/src/lib.rs
+++ b/crates/arb-scanner/src/lib.rs
@@ -259,3 +259,67 @@ pub fn scan_cefi_amm_vol_lag(
 
     out
 }
+
+#[derive(Debug, Clone)]
+pub struct CrossVenueParitySignal {
+    pub instrument_group: String,
+    pub venue_a: VenueId,
+    pub venue_b: VenueId,
+    pub forward_a: f64,
+    pub forward_b: f64,
+    pub forward_gap: f64,
+}
+
+pub fn scan_cross_venue_parity_dislocations(
+    tickers: &[Ticker],
+    risk_free_rate: f64,
+    min_forward_gap: f64,
+) -> Vec<CrossVenueParitySignal> {
+    let mut venue_forwards: HashMap<(VenueId, String), f64> = HashMap::new();
+
+    for parity in scan_put_call_parity(tickers, risk_free_rate) {
+        let (underlying, expiry, strike) = parse_group_key(&parity.instrument_group);
+        let t = year_fraction_from_expiry_code(&expiry);
+        let forward = strike * (-risk_free_rate * t.max(1e-6)).exp() + parity.parity_gap;
+        let key = (parity.venue, format!("{underlying}:{expiry}:{strike}"));
+        venue_forwards.insert(key, forward);
+    }
+
+    let mut grouped: HashMap<String, Vec<(VenueId, f64)>> = HashMap::new();
+    for ((venue, group), forward) in venue_forwards {
+        grouped.entry(group).or_default().push((venue, forward));
+    }
+
+    let mut signals = Vec::new();
+    for (group, values) in grouped {
+        for (i, (venue_a, forward_a)) in values.iter().enumerate() {
+            for (venue_b, forward_b) in values.iter().skip(i + 1) {
+                let gap = forward_a - forward_b;
+                if gap.abs() < min_forward_gap {
+                    continue;
+                }
+                signals.push(CrossVenueParitySignal {
+                    instrument_group: group.clone(),
+                    venue_a: *venue_a,
+                    venue_b: *venue_b,
+                    forward_a: *forward_a,
+                    forward_b: *forward_b,
+                    forward_gap: gap,
+                });
+            }
+        }
+    }
+
+    signals
+}
+
+fn parse_group_key(value: &str) -> (String, String, f64) {
+    let mut parts = value.split(':');
+    let underlying = parts.next().unwrap_or_default().to_string();
+    let expiry = parts.next().unwrap_or_default().to_string();
+    let strike = parts
+        .next()
+        .and_then(|item| item.parse::<f64>().ok())
+        .unwrap_or_default();
+    (underlying, expiry, strike)
+}

--- a/crates/arb-scanner/tests/cross_venue_parity.rs
+++ b/crates/arb-scanner/tests/cross_venue_parity.rs
@@ -1,0 +1,45 @@
+use arb_scanner::scan_cross_venue_parity_dislocations;
+use common::types::{Greeks, Instrument, OptionStyle, OptionType, Ticker, VenueId};
+
+fn option_ticker(venue: VenueId, kind: OptionType, mid: f64) -> Ticker {
+    Ticker {
+        instrument: Instrument {
+            underlying: "BTC".into(),
+            strike: 50000.0,
+            expiry: "27DEC24".into(),
+            option_type: kind,
+            style: OptionStyle::European,
+            venue,
+            venue_symbol: format!("BTC-27DEC24-50000-{}", if matches!(kind, OptionType::Call) {"C"} else {"P"}),
+        },
+        venue,
+        bid: Some(mid - 1.0),
+        ask: Some(mid + 1.0),
+        mid: Some(mid),
+        mark_price: Some(mid),
+        index_price: Some(51000.0),
+        iv: Some(0.6),
+        bid_iv: Some(0.59),
+        ask_iv: Some(0.61),
+        greeks: Greeks::default(),
+        timestamp_ms: 1,
+    }
+}
+
+#[test]
+fn detects_cross_venue_synthetic_forward_gap() {
+    let deribit_call = option_ticker(VenueId::Deribit, OptionType::Call, 2000.0);
+    let deribit_put = option_ticker(VenueId::Deribit, OptionType::Put, 1200.0);
+
+    let aevo_call = option_ticker(VenueId::Aevo, OptionType::Call, 2400.0);
+    let aevo_put = option_ticker(VenueId::Aevo, OptionType::Put, 900.0);
+
+    let signals = scan_cross_venue_parity_dislocations(
+        &[deribit_call, deribit_put, aevo_call, aevo_put],
+        0.01,
+        100.0,
+    );
+
+    assert_eq!(signals.len(), 1);
+    assert!(signals[0].forward_gap.abs() > 100.0);
+}


### PR DESCRIPTION
Implements issue #19.\n\n- Adds synthetic-forward computation per venue\n- Adds cross-venue forward-gap detector\n- Adds unit test for parity dislocation detection\n\nCloses #19