### PR TITLE
feat: 0DTE scanner (Stryke vs Deribit) (#20)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ name = "arb-scanner"
 version = "0.1.0"
 dependencies = [
  "common",
+ "pricing",
  "serde",
 ]
 

--- a/crates/arb-scanner/Cargo.toml
+++ b/crates/arb-scanner/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
+pricing = { path = "../pricing" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/arb-scanner/src/lib.rs
+++ b/crates/arb-scanner/src/lib.rs
@@ -323,3 +323,68 @@ fn parse_group_key(value: &str) -> (String, String, f64) {
         .unwrap_or_default();
     (underlying, expiry, strike)
 }
+
+#[derive(Debug, Clone)]
+pub struct ZeroDteSignal {
+    pub instrument_symbol: String,
+    pub fair_value: f64,
+    pub stryke_price: f64,
+    pub expected_edge: f64,
+    pub timestamp_ms: i64,
+}
+
+pub fn scan_0dte_opportunities(
+    deribit_tickers: &[Ticker],
+    stryke_tickers: &[Ticker],
+    hours_to_expiry: i64,
+    risk_free_rate: f64,
+    min_edge: f64,
+) -> Vec<ZeroDteSignal> {
+    let mut out = Vec::new();
+    let maturity_years = (hours_to_expiry as f64 / 24.0 / 365.0).max(1e-6);
+
+    for deribit in deribit_tickers {
+        for stryke in stryke_tickers {
+            if !match_instrument(&deribit.instrument, &stryke.instrument) {
+                continue;
+            }
+
+            let spot = deribit
+                .index_price
+                .or(deribit.mark_price)
+                .or(stryke.index_price)
+                .unwrap_or(0.0);
+            let strike = deribit.instrument.strike;
+            let iv = deribit.iv.or(deribit.ask_iv).unwrap_or(0.0);
+            let option_kind = match deribit.instrument.option_type {
+                OptionType::Call => pricing::OptionKind::Call,
+                OptionType::Put => pricing::OptionKind::Put,
+            };
+
+            let fair_value = pricing::black_scholes_price(
+                spot,
+                strike,
+                maturity_years,
+                risk_free_rate,
+                iv,
+                option_kind,
+            );
+
+            let stryke_price = stryke.ask.unwrap_or(stryke.mark_price.unwrap_or(0.0));
+            let protocol_fee = stryke_price * 0.15;
+            let expected_edge = fair_value - stryke_price - protocol_fee;
+
+            if expected_edge > min_edge {
+                out.push(ZeroDteSignal {
+                    instrument_symbol: stryke.instrument.venue_symbol.clone(),
+                    fair_value,
+                    stryke_price,
+                    expected_edge,
+                    timestamp_ms: deribit.timestamp_ms.min(stryke.timestamp_ms),
+                });
+            }
+        }
+    }
+
+    out
+}

--- a/crates/arb-scanner/tests/zero_dte.rs
+++ b/crates/arb-scanner/tests/zero_dte.rs
@@ -1,0 +1,43 @@
+use arb_scanner::scan_0dte_opportunities;
+use common::types::{Greeks, Instrument, OptionStyle, OptionType, Ticker, VenueId};
+
+fn mk(venue: VenueId, option_type: OptionType, ask: f64, iv: f64) -> Ticker {
+    Ticker {
+        instrument: Instrument {
+            underlying: "ETH".into(),
+            strike: 3000.0,
+            expiry: "10MAR26".into(),
+            option_type,
+            style: OptionStyle::European,
+            venue,
+            venue_symbol: "ETH-10MAR26-3000-C".into(),
+        },
+        venue,
+        bid: Some(ask - 1.0),
+        ask: Some(ask),
+        mid: Some(ask - 0.5),
+        mark_price: Some(ask),
+        index_price: Some(3200.0),
+        iv: Some(iv),
+        bid_iv: Some(iv - 0.01),
+        ask_iv: Some(iv + 0.01),
+        greeks: Greeks {
+            delta: Some(0.5),
+            gamma: Some(0.0),
+            theta: Some(0.0),
+            vega: Some(20.0),
+            rho: Some(0.0),
+        },
+        timestamp_ms: 1,
+    }
+}
+
+#[test]
+fn detects_0dte_opportunity_when_stryke_is_cheap() {
+    let deribit = mk(VenueId::Deribit, OptionType::Call, 220.0, 0.7);
+    let stryke = mk(VenueId::Stryke, OptionType::Call, 120.0, 0.2);
+
+    let signals = scan_0dte_opportunities(&[deribit], &[stryke], 6, 0.01, 10.0);
+    assert_eq!(signals.len(), 1);
+    assert!(signals[0].expected_edge > 0.0);
+}


### PR DESCRIPTION
Implements issue #20.\n\n- Adds 0DTE arb scanner using Deribit IV-based fair value\n- Adds Stryke protocol fee aware edge computation\n- Adds unit test for cheap-CLAMM opportunity detection\n\nCloses #20