### PR TITLE
feat: Multi-venue executor core (#22)

### DIFF
--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -1,3 +1,91 @@
-pub fn crate_name() -> &'static str {
-    "executor"
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderStatus {
+    Pending,
+    Filled,
+    Partial,
+    Cancelled,
+}
+
+#[derive(Debug, Clone)]
+pub struct VenueOrder {
+    pub id: String,
+    pub venue: String,
+    pub status: OrderStatus,
+}
+
+impl VenueOrder {
+    pub fn new(id: &str, venue: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            venue: venue.to_string(),
+            status: OrderStatus::Pending,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OrderRequest {
+    pub venue: String,
+    pub instrument: String,
+    pub size: f64,
+    pub is_buy: bool,
+}
+
+impl OrderRequest {
+    pub fn new(venue: &str, instrument: &str, size: f64, is_buy: bool) -> Self {
+        Self {
+            venue: venue.to_string(),
+            instrument: instrument.to_string(),
+            size,
+            is_buy,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AtomicExecutionPlan {
+    pub legs: Vec<OrderRequest>,
+    pub cancel_on_disconnect: bool,
+}
+
+#[derive(Default)]
+pub struct ExecutorState {
+    orders: HashMap<String, VenueOrder>,
+}
+
+impl ExecutorState {
+    pub fn track(&mut self, order: VenueOrder) {
+        self.orders.insert(order.id.clone(), order);
+    }
+
+    pub fn update_status(&mut self, order_id: &str, status: OrderStatus) {
+        if let Some(order) = self.orders.get_mut(order_id) {
+            order.status = status;
+        }
+    }
+
+    pub fn get(&self, order_id: &str) -> Option<&VenueOrder> {
+        self.orders.get(order_id)
+    }
+}
+
+pub fn calc_fee_aware_size(capital: f64, price: f64, fee_rate: f64) -> f64 {
+    if price <= 0.0 {
+        return 0.0;
+    }
+    capital / (price * (1.0 + fee_rate))
+}
+
+pub fn execute_atomic_pair(buy_leg: &OrderRequest, sell_leg: &OrderRequest) -> AtomicExecutionPlan {
+    AtomicExecutionPlan {
+        legs: vec![buy_leg.clone(), sell_leg.clone()],
+        cancel_on_disconnect: true,
+    }
+}
+
+pub fn next_retry_delay_ms(attempt: u32) -> u64 {
+    let value = 500_u64.saturating_mul(2_u64.saturating_pow(attempt));
+    value.min(30_000)
 }

--- a/crates/executor/tests/executor.rs
+++ b/crates/executor/tests/executor.rs
@@ -1,0 +1,34 @@
+use executor::{
+    calc_fee_aware_size, execute_atomic_pair, next_retry_delay_ms, ExecutorState, OrderRequest,
+    OrderStatus, VenueOrder,
+};
+
+#[test]
+fn computes_fee_aware_size() {
+    let size = calc_fee_aware_size(1000.0, 200.0, 0.001);
+    assert!(size > 4.9 && size < 5.0);
+}
+
+#[test]
+fn transitions_order_state() {
+    let mut state = ExecutorState::default();
+    state.track(VenueOrder::new("o1", "Deribit"));
+    state.update_status("o1", OrderStatus::Filled);
+    assert_eq!(state.get("o1").unwrap().status, OrderStatus::Filled);
+}
+
+#[test]
+fn executes_atomic_pair_plan() {
+    let buy = OrderRequest::new("Deribit", "ETH-28MAR26-3000-C", 1.0, true);
+    let sell = OrderRequest::new("Aevo", "ETH-28MAR26-3000-C", 1.0, false);
+    let plan = execute_atomic_pair(&buy, &sell);
+    assert_eq!(plan.legs.len(), 2);
+    assert!(plan.cancel_on_disconnect);
+}
+
+#[test]
+fn backoff_is_capped() {
+    assert_eq!(next_retry_delay_ms(0), 500);
+    assert_eq!(next_retry_delay_ms(1), 1000);
+    assert_eq!(next_retry_delay_ms(10), 30_000);
+}


### PR DESCRIPTION
Implements issue #22.\n\n- Adds venue-neutral order request abstraction\n- Adds fee-aware position sizing utility\n- Adds atomic multi-leg execution plan type\n- Adds retry backoff helper\n- Adds order status tracking state machine\n\nCloses #22