### PR TITLE
feat: Paper trading mode and monitoring (#24)

### DIFF
--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -89,3 +89,111 @@ pub fn next_retry_delay_ms(attempt: u32) -> u64 {
     let value = 500_u64.saturating_mul(2_u64.saturating_pow(attempt));
     value.min(30_000)
 }
+
+#[derive(Debug, Clone)]
+pub struct PaperFill {
+    pub signal_id: String,
+    pub entry_price: f64,
+    pub exit_price: f64,
+    pub size: f64,
+}
+
+impl PaperFill {
+    pub fn new(signal_id: &str, entry_price: f64, exit_price: f64, size: f64) -> Self {
+        Self {
+            signal_id: signal_id.to_string(),
+            entry_price,
+            exit_price,
+            size,
+        }
+    }
+
+    pub fn pnl(&self) -> f64 {
+        (self.exit_price - self.entry_price) * self.size
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PrometheusSnapshot {
+    pub signals_per_min: f64,
+    pub fill_rate: f64,
+    pub pnl: f64,
+    pub avg_latency_ms: f64,
+}
+
+#[derive(Default)]
+pub struct PaperTrader {
+    fills: Vec<PaperFill>,
+    signals_seen: u64,
+    latencies_ms: Vec<f64>,
+}
+
+impl PaperTrader {
+    pub fn record_signal_latency_ms(&mut self, latency: f64) {
+        self.signals_seen += 1;
+        self.latencies_ms.push(latency);
+    }
+
+    pub fn record_fill(&mut self, fill: PaperFill) {
+        self.signals_seen += 1;
+        self.fills.push(fill);
+    }
+
+    pub fn total_pnl(&self) -> f64 {
+        self.fills.iter().map(PaperFill::pnl).sum()
+    }
+
+    pub fn hit_rate(&self) -> f64 {
+        if self.fills.is_empty() {
+            return 0.0;
+        }
+        let wins = self.fills.iter().filter(|fill| fill.pnl() > 0.0).count() as f64;
+        wins / self.fills.len() as f64
+    }
+
+    pub fn metrics_snapshot(&self, minutes: f64) -> PrometheusSnapshot {
+        let avg_latency = if self.latencies_ms.is_empty() {
+            0.0
+        } else {
+            self.latencies_ms.iter().sum::<f64>() / self.latencies_ms.len() as f64
+        };
+
+        PrometheusSnapshot {
+            signals_per_min: if minutes > 0.0 {
+                self.signals_seen as f64 / minutes
+            } else {
+                0.0
+            },
+            fill_rate: if self.signals_seen > 0 {
+                self.fills.len() as f64 / self.signals_seen as f64
+            } else {
+                0.0
+            },
+            pnl: self.total_pnl(),
+            avg_latency_ms: avg_latency,
+        }
+    }
+}
+
+pub fn check_risk_alert(utilization: f64, max_allowed: f64) -> Option<String> {
+    if utilization > max_allowed {
+        Some(format!(
+            "risk utilization breached: current={utilization:.2}, limit={max_allowed:.2}"
+        ))
+    } else {
+        None
+    }
+}
+
+pub fn build_grafana_dashboard_template() -> String {
+    r#"{
+  "title": "options-arb paper trading",
+  "panels": [
+    {"title": "signals_per_min", "type": "timeseries"},
+    {"title": "fill_rate", "type": "timeseries"},
+    {"title": "pnl", "type": "timeseries"},
+    {"title": "latency_ms", "type": "timeseries"}
+  ]
+}"#
+    .to_string()
+}

--- a/crates/executor/tests/paper_trading.rs
+++ b/crates/executor/tests/paper_trading.rs
@@ -1,0 +1,38 @@
+use executor::{
+    build_grafana_dashboard_template, check_risk_alert, PaperFill, PaperTrader, PrometheusSnapshot,
+};
+
+#[test]
+fn tracks_pnl_and_hit_rate() {
+    let mut trader = PaperTrader::default();
+    trader.record_fill(PaperFill::new("s1", 100.0, 110.0, 1.0));
+    trader.record_fill(PaperFill::new("s2", 100.0, 95.0, 1.0));
+
+    assert!((trader.total_pnl() - 5.0).abs() < 1e-9);
+    assert!((trader.hit_rate() - 0.5).abs() < 1e-9);
+}
+
+#[test]
+fn emits_prometheus_snapshot() {
+    let mut trader = PaperTrader::default();
+    trader.record_signal_latency_ms(42.0);
+    trader.record_fill(PaperFill::new("s1", 100.0, 101.0, 1.0));
+
+    let snap: PrometheusSnapshot = trader.metrics_snapshot(60.0);
+    assert!(snap.signals_per_min >= 0.0);
+    assert!(snap.fill_rate >= 0.0);
+}
+
+#[test]
+fn risk_alerts_when_utilization_high() {
+    assert!(check_risk_alert(0.91, 0.90).is_some());
+    assert!(check_risk_alert(0.50, 0.90).is_none());
+}
+
+#[test]
+fn provides_grafana_template_json() {
+    let json = build_grafana_dashboard_template();
+    assert!(json.contains("signals_per_min"));
+    assert!(json.contains("fill_rate"));
+    assert!(json.contains("pnl"));
+}


### PR DESCRIPTION
Implements issue #24.\n\n- Adds paper-trade fill and PnL tracking\n- Adds hit-rate and latency metric snapshot helpers\n- Adds risk limit breach alert helper\n- Adds Grafana dashboard template output\n- Adds unit tests for monitoring behavior\n\nCloses #24