### PR TITLE
fix: parse expiry to accurate year fraction (#55)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +36,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "arb-scanner"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "common",
  "pricing",
  "serde",
@@ -139,6 +149,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "common"
@@ -856,6 +877,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1315,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "common",
+ "executor",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2227,6 +2273,7 @@ dependencies = [
  "common",
  "serde_json",
  "sqlx",
+ "tokio",
 ]
 
 [[package]]
@@ -2385,7 +2432,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2844,6 +2903,41 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/arb-scanner/Cargo.toml
+++ b/crates/arb-scanner/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 common = { path = "../common" }
 pricing = { path = "../pricing" }
 serde = { version = "1", features = ["derive"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/crates/arb-scanner/src/lib.rs
+++ b/crates/arb-scanner/src/lib.rs
@@ -1,3 +1,4 @@
+use chrono::{NaiveDate, Utc};
 use std::collections::HashMap;
 
 use common::types::{match_instrument, OptionType, Ticker, VenueId};
@@ -213,8 +214,46 @@ fn estimated_slippage(buy: &Ticker, sell: &Ticker, bps: f64) -> f64 {
     notional * bps / 10_000.0
 }
 
-fn year_fraction_from_expiry_code(_expiry: &str) -> f64 {
-    30.0 / 365.0
+fn year_fraction_from_expiry_code(expiry: &str) -> f64 {
+    let now = Utc::now().date_naive();
+    year_fraction_from_expiry_code_with_now(expiry, now)
+}
+
+fn year_fraction_from_expiry_code_with_now(expiry: &str, now: NaiveDate) -> f64 {
+    let maybe_date = parse_expiry_date(expiry);
+    let Some(expiry_date) = maybe_date else {
+        return 30.0 / 365.0;
+    };
+
+    let days = (expiry_date - now).num_days().max(0) as f64;
+    days / 365.0
+}
+
+fn parse_expiry_date(expiry: &str) -> Option<NaiveDate> {
+    if expiry.len() != 7 {
+        return None;
+    }
+
+    let day = expiry[0..2].parse::<u32>().ok()?;
+    let month = match &expiry[2..5].to_ascii_uppercase()[..] {
+        "JAN" => 1,
+        "FEB" => 2,
+        "MAR" => 3,
+        "APR" => 4,
+        "MAY" => 5,
+        "JUN" => 6,
+        "JUL" => 7,
+        "AUG" => 8,
+        "SEP" => 9,
+        "OCT" => 10,
+        "NOV" => 11,
+        "DEC" => 12,
+        _ => return None,
+    };
+    let year_suffix = expiry[5..7].parse::<i32>().ok()?;
+    let year = 2000 + year_suffix;
+
+    NaiveDate::from_ymd_opt(year, month, day)
 }
 
 #[derive(Debug, Clone)]
@@ -597,5 +636,31 @@ pub fn generate_surface_trade_legs(signal: &SurfaceArbSignal) -> Vec<SurfaceTrad
                 maturity_years: signal.maturity_years,
             },
         ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_expiry_date, year_fraction_from_expiry_code_with_now};
+    use chrono::NaiveDate;
+
+    #[test]
+    fn parses_exchange_expiry_code() {
+        let parsed = parse_expiry_date("28MAR26").expect("date parsed");
+        assert_eq!(parsed, NaiveDate::from_ymd_opt(2026, 3, 28).unwrap());
+    }
+
+    #[test]
+    fn computes_year_fraction_from_actual_expiry() {
+        let now = NaiveDate::from_ymd_opt(2025, 3, 28).unwrap();
+        let t = year_fraction_from_expiry_code_with_now("28MAR26", now);
+        assert!((t - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn invalid_expiry_falls_back_to_30_days() {
+        let now = NaiveDate::from_ymd_opt(2025, 3, 28).unwrap();
+        let t = year_fraction_from_expiry_code_with_now("bad", now);
+        assert!((t - (30.0 / 365.0)).abs() < 1e-12);
     }
 }


### PR DESCRIPTION
Implements issue #55.\n\n- Replaces fixed 30-day fraction with parsed expiry-based value\n- Supports DDMmmYY codes used by exchanges\n- Keeps fallback for invalid inputs\n- Adds targeted unit tests\n\nCloses #55