### PR TITLE
fix: use practical strike tolerance in instrument matching (#56)

### DIFF
--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -65,7 +65,7 @@ impl Instrument {
 pub fn match_instrument(a: &Instrument, b: &Instrument) -> bool {
     a.underlying == b.underlying
         && a.expiry == b.expiry
-        && (a.strike - b.strike).abs() < f64::EPSILON
+        && (a.strike - b.strike).abs() < 0.01
         && a.option_type == b.option_type
 }
 

--- a/crates/common/tests/types_normalization.rs
+++ b/crates/common/tests/types_normalization.rs
@@ -60,3 +60,22 @@ fn converts_derive_ticker_to_unified_ticker() {
     assert_eq!(ticker.venue, VenueId::Derive);
     assert_eq!(ticker.iv, Some(0.60));
 }
+
+#[test]
+fn matches_instruments_with_small_strike_float_noise() {
+    let mut a = common::types::Instrument::from_clob_symbol(
+        VenueId::Deribit,
+        "ETH-28MAR26-3000-C",
+    )
+    .unwrap();
+    let mut b = common::types::Instrument::from_clob_symbol(
+        VenueId::Aevo,
+        "ETH-28MAR26-3000-C",
+    )
+    .unwrap();
+
+    a.strike = 3000.0000001;
+    b.strike = 3000.0000002;
+
+    assert!(match_instrument(&a, &b));
+}


### PR DESCRIPTION
Implements issue #56.\n\n- Adds regression test for float strike noise\n- Replaces f64::EPSILON comparison with 0.01 tolerance\n\nCloses #56