### PR TITLE
fix: avoid invalid Premia oracle address usage (#57)

### DIFF
--- a/crates/connector-premia/src/lib.rs
+++ b/crates/connector-premia/src/lib.rs
@@ -3,7 +3,7 @@ use common::types::{Greeks, Instrument, OptionStyle, OptionType, Ticker, VenueId
 
 pub const PREMIA_QUOTES_WS: &str = "wss://quotes.premia.finance";
 const PREMIA_SUBGRAPH: &str = "https://api.thegraph.com/subgraphs/name/premian-labs/premia-blue";
-const PREMIA_ORACLE: &str = "0x23c74Cb00000000000000000000000000000000";
+const PREMIA_ORACLE: Option<&str> = None;
 
 #[derive(Debug, Clone)]
 pub struct PremiaQuoteRequest {
@@ -17,8 +17,15 @@ pub fn premia_subgraph_url() -> &'static str {
     PREMIA_SUBGRAPH
 }
 
-pub fn premia_oracle_address() -> &'static str {
-    PREMIA_ORACLE
+pub fn premia_oracle_address() -> Option<&'static str> {
+    PREMIA_ORACLE.filter(|value| is_valid_evm_address(value))
+}
+
+pub fn is_valid_evm_address(value: &str) -> bool {
+    if value.len() != 42 || !value.starts_with("0x") {
+        return false;
+    }
+    value[2..].chars().all(|item| item.is_ascii_hexdigit())
 }
 
 pub fn build_quote_request(chain: &str, pool: &str, size: f64, is_buy: bool) -> PremiaQuoteRequest {

--- a/crates/connector-premia/tests/premia_collector.rs
+++ b/crates/connector-premia/tests/premia_collector.rs
@@ -1,14 +1,17 @@
 use common::types::VenueId;
 use connector_premia::{
-    build_quote_request, normalize_quote_to_ticker, premia_oracle_address, premia_subgraph_url,
-    PREMIA_QUOTES_WS,
+    build_quote_request, is_valid_evm_address, normalize_quote_to_ticker, premia_oracle_address,
+    premia_subgraph_url, PREMIA_QUOTES_WS,
 };
 
 #[test]
 fn exposes_required_endpoints() {
     assert_eq!(PREMIA_QUOTES_WS, "wss://quotes.premia.finance");
     assert!(premia_subgraph_url().contains("premia-blue"));
-    assert!(premia_oracle_address().starts_with("0x"));
+    assert!(premia_oracle_address().is_none());
+    assert!(is_valid_evm_address(
+        "0x1111111111111111111111111111111111111111"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Implements issue #57.\n\n- Removes invalid hardcoded oracle address\n- Returns optional oracle address with format validation\n- Adds EVM address validator and test coverage\n\nCloses #57