### PR TITLE
refactor: async tokio main and metrics listener (#58)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,7 @@ dependencies = [
  "anyhow",
  "common",
  "executor",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/bin/options-arb/Cargo.toml
+++ b/bin/options-arb/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../../crates/common" }
 executor = { path = "../../crates/executor" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 anyhow = "1"

--- a/bin/options-arb/src/main.rs
+++ b/bin/options-arb/src/main.rs
@@ -1,27 +1,28 @@
 use anyhow::Result;
 use common::AppConfig;
 use executor::{render_prometheus, PaperTrader, PrometheusSnapshot};
-use std::io::{Read, Write};
-use std::net::TcpListener;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
     let cfg = AppConfig::load()?;
     tracing::info!(environment = %cfg.environment, "options-arb boot");
 
     if let Ok(bind) = std::env::var("METRICS_BIND") {
-        run_metrics_server(&bind)?;
+        run_metrics_server(&bind).await?;
     }
 
     Ok(())
 }
 
-fn run_metrics_server(bind: &str) -> Result<()> {
-    let listener = TcpListener::bind(bind)?;
+async fn run_metrics_server(bind: &str) -> Result<()> {
+    let listener = TcpListener::bind(bind).await?;
     tracing::info!(%bind, "metrics endpoint started");
 
-    for stream in listener.incoming() {
-        let mut stream = match stream {
+    loop {
+        let (mut stream, _addr) = match listener.accept().await {
             Ok(value) => value,
             Err(err) => {
                 tracing::warn!(error = %err, "incoming metrics stream error");
@@ -30,27 +31,46 @@ fn run_metrics_server(bind: &str) -> Result<()> {
         };
 
         let mut request = [0_u8; 1024];
-        let _ = stream.read(&mut request);
+        let _ = stream.read(&mut request).await;
         let request_text = String::from_utf8_lossy(&request);
 
-        if request_text.starts_with("GET /metrics") {
-            let snapshot = PrometheusSnapshot {
-                signals_per_min: 0.0,
-                fill_rate: 0.0,
-                pnl: PaperTrader::default().total_pnl(),
-                avg_latency_ms: 0.0,
-            };
-            let body = render_prometheus(&snapshot, 0.0);
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            stream.write_all(response.as_bytes())?;
-        } else {
-            stream.write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")?;
-        }
+        let response = build_http_response(&request_text);
+        stream.write_all(response.as_bytes()).await?;
+    }
+}
+
+fn build_http_response(request_text: &str) -> String {
+    if request_text.starts_with("GET /metrics") {
+        let snapshot = PrometheusSnapshot {
+            signals_per_min: 0.0,
+            fill_rate: 0.0,
+            pnl: PaperTrader::default().total_pnl(),
+            avg_latency_ms: 0.0,
+        };
+        let body = render_prometheus(&snapshot, 0.0);
+        return format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
     }
 
-    Ok(())
+    "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_http_response;
+
+    #[test]
+    fn metrics_path_returns_ok() {
+        let response = build_http_response("GET /metrics HTTP/1.1\r\n\r\n");
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+    }
+
+    #[test]
+    fn unknown_path_returns_404() {
+        let response = build_http_response("GET /unknown HTTP/1.1\r\n\r\n");
+        assert!(response.starts_with("HTTP/1.1 404 Not Found"));
+    }
 }


### PR DESCRIPTION
Implements issue #58.\n\n- Migrates main to tokio async runtime\n- Replaces blocking TcpListener with tokio TcpListener\n- Adds response builder tests for /metrics and 404 behavior\n\nCloses #58