### PR TITLE
refactor: use sqlx migration runner for storage schema (#59)

### DIFF
--- a/crates/storage/migrations/001_init_timescaledb.sql
+++ b/crates/storage/migrations/001_init_timescaledb.sql
@@ -1,0 +1,59 @@
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+CREATE TABLE IF NOT EXISTS tickers (
+    id BIGSERIAL,
+    venue TEXT NOT NULL,
+    instrument TEXT NOT NULL,
+    bid DOUBLE PRECISION,
+    ask DOUBLE PRECISION,
+    mid DOUBLE PRECISION,
+    iv DOUBLE PRECISION,
+    bid_iv DOUBLE PRECISION,
+    ask_iv DOUBLE PRECISION,
+    greeks JSONB,
+    timestamp_ms BIGINT NOT NULL,
+    PRIMARY KEY (id, timestamp_ms)
+);
+
+CREATE TABLE IF NOT EXISTS orderbook_snapshots (
+    id BIGSERIAL PRIMARY KEY,
+    venue TEXT NOT NULL,
+    instrument TEXT NOT NULL,
+    bids JSONB NOT NULL,
+    asks JSONB NOT NULL,
+    timestamp_ms BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS trades (
+    id BIGSERIAL,
+    venue TEXT NOT NULL,
+    instrument TEXT NOT NULL,
+    price DOUBLE PRECISION NOT NULL,
+    size DOUBLE PRECISION NOT NULL,
+    side TEXT NOT NULL,
+    timestamp_ms BIGINT NOT NULL,
+    PRIMARY KEY (id, timestamp_ms)
+);
+
+CREATE TABLE IF NOT EXISTS arb_signals (
+    id BIGSERIAL PRIMARY KEY,
+    venues TEXT NOT NULL,
+    instrument TEXT NOT NULL,
+    iv_spread DOUBLE PRECISION NOT NULL,
+    estimated_pnl DOUBLE PRECISION NOT NULL,
+    signal_type TEXT NOT NULL,
+    timestamp_ms BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS positions (
+    id BIGSERIAL PRIMARY KEY,
+    venue TEXT NOT NULL,
+    instrument TEXT NOT NULL,
+    size DOUBLE PRECISION NOT NULL,
+    entry_price DOUBLE PRECISION NOT NULL,
+    current_pnl DOUBLE PRECISION NOT NULL,
+    timestamp_ms BIGINT NOT NULL
+);
+
+SELECT create_hypertable('tickers', by_range('timestamp_ms'), if_not_exists => TRUE);
+SELECT create_hypertable('trades', by_range('timestamp_ms'), if_not_exists => TRUE);

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -16,65 +16,7 @@ impl Default for StorageConfig {
 }
 
 pub fn migrations_sql() -> &'static str {
-    r#"
-CREATE EXTENSION IF NOT EXISTS timescaledb;
-
-CREATE TABLE IF NOT EXISTS tickers (
-    id BIGSERIAL PRIMARY KEY,
-    venue TEXT NOT NULL,
-    instrument TEXT NOT NULL,
-    bid DOUBLE PRECISION,
-    ask DOUBLE PRECISION,
-    mid DOUBLE PRECISION,
-    iv DOUBLE PRECISION,
-    bid_iv DOUBLE PRECISION,
-    ask_iv DOUBLE PRECISION,
-    greeks JSONB,
-    timestamp_ms BIGINT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS orderbook_snapshots (
-    id BIGSERIAL PRIMARY KEY,
-    venue TEXT NOT NULL,
-    instrument TEXT NOT NULL,
-    bids JSONB NOT NULL,
-    asks JSONB NOT NULL,
-    timestamp_ms BIGINT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS trades (
-    id BIGSERIAL PRIMARY KEY,
-    venue TEXT NOT NULL,
-    instrument TEXT NOT NULL,
-    price DOUBLE PRECISION NOT NULL,
-    size DOUBLE PRECISION NOT NULL,
-    side TEXT NOT NULL,
-    timestamp_ms BIGINT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS arb_signals (
-    id BIGSERIAL PRIMARY KEY,
-    venues TEXT NOT NULL,
-    instrument TEXT NOT NULL,
-    iv_spread DOUBLE PRECISION NOT NULL,
-    estimated_pnl DOUBLE PRECISION NOT NULL,
-    signal_type TEXT NOT NULL,
-    timestamp_ms BIGINT NOT NULL
-);
-
-CREATE TABLE IF NOT EXISTS positions (
-    id BIGSERIAL PRIMARY KEY,
-    venue TEXT NOT NULL,
-    instrument TEXT NOT NULL,
-    size DOUBLE PRECISION NOT NULL,
-    entry_price DOUBLE PRECISION NOT NULL,
-    current_pnl DOUBLE PRECISION NOT NULL,
-    timestamp_ms BIGINT NOT NULL
-);
-
-SELECT create_hypertable('tickers', by_range('timestamp_ms'), if_not_exists => TRUE);
-SELECT create_hypertable('trades', by_range('timestamp_ms'), if_not_exists => TRUE);
-"#
+    include_str!("../migrations/001_init_timescaledb.sql")
 }
 
 pub fn retention_policy_sql(config: &StorageConfig) -> String {
@@ -96,15 +38,7 @@ impl SqlStorage {
     }
 
     pub async fn migrate(&self, config: &StorageConfig) -> Result<()> {
-        for statement in migrations_sql()
-            .split(';')
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            sqlx::query(&format!("{statement};"))
-                .execute(&self.pool)
-                .await?;
-        }
+        sqlx::migrate!("./migrations").run(&self.pool).await?;
 
         sqlx::query(&retention_policy_sql(config))
             .execute(&self.pool)


### PR DESCRIPTION
Implements issue #59.\n\n- Adds versioned SQL migration file\n- Replaces semicolon-splitting execution with sqlx::migrate!\n- Keeps retention policy execution in migrate path\n\nCloses #59