### PR TITLE
chore: remove unused workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 alloy = "1"
-optionstratlib = "0.15"
-implied-vol = "2.0"
-volsurf = "1.0"
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }
 tracing = "0.1"
 config = "0.15"


### PR DESCRIPTION
Closes #61\n\n- remove unused workspace deps: optionstratlib, implied-vol, volsurf\n- run cargo check and cargo test