### PR TITLE
feat: integrate live async order execution path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,12 @@ dependencies = [
 name = "executor"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "common",
+ "reqwest",
+ "risk-manager",
+ "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -5,3 +5,11 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
+anyhow = "1"
+risk-manager = { path = "../risk-manager" }
+tokio = { workspace = true, features = ["time"] }
+reqwest = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -1,4 +1,10 @@
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+
+use anyhow::{anyhow, Result};
+use risk_manager::FlattenOrder;
+use tokio::time::{timeout, Duration};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OrderStatus {
@@ -82,6 +88,143 @@ pub fn execute_atomic_pair(buy_leg: &OrderRequest, sell_leg: &OrderRequest) -> A
     AtomicExecutionPlan {
         legs: vec![buy_leg.clone(), sell_leg.clone()],
         cancel_on_disconnect: true,
+    }
+}
+
+pub trait VenueOrderClient {
+    fn place_order<'a>(
+        &'a self,
+        request: &'a OrderRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<VenueOrder>> + Send + 'a>>;
+}
+
+pub async fn execute_atomic_pair_live<C: VenueOrderClient + Sync>(
+    client: &C,
+    buy_leg: &OrderRequest,
+    sell_leg: &OrderRequest,
+    timeout_ms: u64,
+) -> Result<Vec<VenueOrder>> {
+    let execution = timeout(
+        Duration::from_millis(timeout_ms),
+        async {
+            let buy_future = client.place_order(buy_leg);
+            let sell_future = client.place_order(sell_leg);
+            tokio::try_join!(buy_future, sell_future)
+        },
+    )
+    .await
+    .map_err(|_| anyhow!("atomic execution timed out"))?;
+
+    let (buy_order, sell_order) = execution?;
+    Ok(vec![buy_order, sell_order])
+}
+
+pub fn flatten_orders_to_requests(venue: &str, flatten_orders: &[FlattenOrder]) -> Vec<OrderRequest> {
+    flatten_orders
+        .iter()
+        .filter(|order| order.size.abs() > 0.0)
+        .map(|order| OrderRequest {
+            venue: venue.to_string(),
+            instrument: order.instrument.clone(),
+            size: order.size.abs(),
+            is_buy: order.size > 0.0,
+        })
+        .collect()
+}
+
+pub async fn execute_kill_switch<C: VenueOrderClient + Sync>(
+    client: &C,
+    venue: &str,
+    flatten_orders: &[FlattenOrder],
+    timeout_ms: u64,
+) -> Result<Vec<VenueOrder>> {
+    let requests = flatten_orders_to_requests(venue, flatten_orders);
+    let mut placed_orders = Vec::with_capacity(requests.len());
+
+    for request in requests {
+        let placed = timeout(Duration::from_millis(timeout_ms), client.place_order(&request))
+            .await
+            .map_err(|_| anyhow!("kill switch execution timed out"))??;
+        placed_orders.push(placed);
+    }
+
+    Ok(placed_orders)
+}
+
+#[derive(Clone, Default)]
+pub struct HttpOrderClient {
+    client: reqwest::Client,
+    venue_endpoints: HashMap<String, String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct HttpOrderPayload<'a> {
+    instrument: &'a str,
+    size: f64,
+    side: &'a str,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct HttpOrderResponse {
+    order_id: Option<String>,
+    status: Option<String>,
+}
+
+impl HttpOrderClient {
+    pub fn with_endpoint(mut self, venue: &str, endpoint: &str) -> Self {
+        self.venue_endpoints
+            .insert(venue.to_string(), endpoint.to_string());
+        self
+    }
+}
+
+impl VenueOrderClient for HttpOrderClient {
+    fn place_order<'a>(
+        &'a self,
+        request: &'a OrderRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<VenueOrder>> + Send + 'a>> {
+        Box::pin(async move {
+            let endpoint = self
+                .venue_endpoints
+                .get(&request.venue)
+                .ok_or_else(|| anyhow!("missing endpoint for venue {}", request.venue))?;
+
+            let payload = HttpOrderPayload {
+                instrument: &request.instrument,
+                size: request.size,
+                side: if request.is_buy { "buy" } else { "sell" },
+            };
+
+            let response = self
+                .client
+                .post(endpoint)
+                .json(&payload)
+                .send()
+                .await?
+                .error_for_status()?;
+
+            let parsed = response.json::<HttpOrderResponse>().await.ok();
+            let order_id = parsed
+                .as_ref()
+                .and_then(|item| item.order_id.clone())
+                .unwrap_or_else(|| format!("{}:{}", request.venue, request.instrument));
+            let status = match parsed
+                .as_ref()
+                .and_then(|item| item.status.as_deref())
+                .unwrap_or("pending")
+            {
+                "filled" => OrderStatus::Filled,
+                "partial" => OrderStatus::Partial,
+                "cancelled" => OrderStatus::Cancelled,
+                _ => OrderStatus::Pending,
+            };
+
+            Ok(VenueOrder {
+                id: order_id,
+                venue: request.venue.clone(),
+                status,
+            })
+        })
     }
 }
 

--- a/crates/executor/tests/executor.rs
+++ b/crates/executor/tests/executor.rs
@@ -1,7 +1,32 @@
 use executor::{
-    calc_fee_aware_size, execute_atomic_pair, next_retry_delay_ms, ExecutorState, OrderRequest,
-    OrderStatus, VenueOrder,
+    calc_fee_aware_size, execute_atomic_pair, execute_atomic_pair_live, execute_kill_switch,
+    flatten_orders_to_requests, next_retry_delay_ms, ExecutorState, OrderRequest, OrderStatus,
+    VenueOrder, VenueOrderClient,
 };
+use risk_manager::FlattenOrder;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+struct MockVenueClient {
+    seen: Arc<Mutex<Vec<OrderRequest>>>,
+}
+
+impl VenueOrderClient for MockVenueClient {
+    fn place_order<'a>(
+        &'a self,
+        request: &'a OrderRequest,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<VenueOrder>> + Send + 'a>> {
+        Box::pin(async move {
+            self.seen.lock().unwrap().push(request.clone());
+            Ok(VenueOrder::new(
+                &format!("{}:{}", request.venue, request.instrument),
+                &request.venue,
+            ))
+        })
+    }
+}
 
 #[test]
 fn computes_fee_aware_size() {
@@ -31,4 +56,63 @@ fn backoff_is_capped() {
     assert_eq!(next_retry_delay_ms(0), 500);
     assert_eq!(next_retry_delay_ms(1), 1000);
     assert_eq!(next_retry_delay_ms(10), 30_000);
+}
+
+#[test]
+fn maps_flatten_orders_to_actionable_requests() {
+    let flatten = vec![
+        FlattenOrder {
+            instrument: "ETH-28MAR26-3000-C".to_string(),
+            size: -2.0,
+        },
+        FlattenOrder {
+            instrument: "BTC-28MAR26-50000-P".to_string(),
+            size: 1.5,
+        },
+    ];
+
+    let requests = flatten_orders_to_requests("Deribit", &flatten);
+    assert_eq!(requests.len(), 2);
+    assert!(!requests[0].is_buy);
+    assert!((requests[0].size - 2.0).abs() < 1e-9);
+    assert!(requests[1].is_buy);
+    assert!((requests[1].size - 1.5).abs() < 1e-9);
+}
+
+#[tokio::test]
+async fn executes_atomic_pair_live_via_order_client() {
+    let client = MockVenueClient::default();
+    let buy = OrderRequest::new("Deribit", "ETH-28MAR26-3000-C", 1.0, true);
+    let sell = OrderRequest::new("Aevo", "ETH-28MAR26-3000-C", 1.0, false);
+
+    let orders = execute_atomic_pair_live(&client, &buy, &sell, 2_000)
+        .await
+        .expect("atomic execution should succeed");
+
+    assert_eq!(orders.len(), 2);
+    assert_eq!(client.seen.lock().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn executes_kill_switch_orders_through_executor() {
+    let client = MockVenueClient::default();
+    let flatten = vec![
+        FlattenOrder {
+            instrument: "ETH-28MAR26-3000-C".to_string(),
+            size: -2.0,
+        },
+        FlattenOrder {
+            instrument: "BTC-28MAR26-50000-P".to_string(),
+            size: 1.0,
+        },
+    ];
+
+    let orders = execute_kill_switch(&client, "Deribit", &flatten, 2_000)
+        .await
+        .expect("kill switch execution should succeed");
+
+    assert_eq!(orders.len(), 2);
+    let seen = client.seen.lock().unwrap();
+    assert_eq!(seen.len(), 2);
+    assert_eq!(seen[0].venue, "Deribit");
 }


### PR DESCRIPTION
Closes #60\n\n- add async execution API for atomic legs with timeout\n- add HTTP order client that issues real POST requests\n- wire risk-manager flatten orders into kill-switch execution flow\n- add tests for atomic live execution and kill-switch routing