### PR TITLE
feat: add websocket heartbeat and reconnect replay support

### DIFF
--- a/crates/connector-deribit/src/lib.rs
+++ b/crates/connector-deribit/src/lib.rs
@@ -249,6 +249,30 @@ impl DeribitWsClient {
         Err(anyhow!("failed to reconnect after retries"))
     }
 
+    pub async fn reconnect_and_resubscribe(&self, channels: &[String]) -> Result<()> {
+        for attempt in 0..=5 {
+            match connect_async(self.url).await {
+                Ok((mut ws, _)) => {
+                    let heartbeat = build_set_heartbeat_request(1, 60);
+                    ws.send(Message::Text(heartbeat.to_string().into())).await?;
+
+                    if !channels.is_empty() {
+                        let subscribe = build_subscribe_request(2, channels);
+                        ws.send(Message::Text(subscribe.to_string().into())).await?;
+                    }
+
+                    ws.close(None).await?;
+                    return Ok(());
+                }
+                Err(_) => {
+                    sleep(Duration::from_millis(backoff_delay_ms(attempt))).await;
+                }
+            }
+        }
+
+        Err(anyhow!("failed to reconnect and resubscribe"))
+    }
+
     async fn connect_once(&self) -> Result<()> {
         let (mut ws, _) = connect_async(self.url).await?;
         ws.close(None).await?;
@@ -274,6 +298,40 @@ pub fn build_subscribe_request(id: u64, channels: &[String]) -> Value {
         "method": "public/subscribe",
         "params": { "channels": channels },
     })
+}
+
+pub fn build_set_heartbeat_request(id: u64, interval_sec: u64) -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "public/set_heartbeat",
+        "params": {
+            "interval": interval_sec,
+        }
+    })
+}
+
+pub fn build_public_test_request(id: u64) -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "public/test",
+        "params": {}
+    })
+}
+
+pub fn heartbeat_reply_if_requested(incoming_text: &str) -> Result<Option<Value>> {
+    let parsed: Value = serde_json::from_str(incoming_text)?;
+    if parsed["method"].as_str() != Some("heartbeat") {
+        return Ok(None);
+    }
+
+    if parsed["params"]["type"].as_str() == Some("test_request") {
+        let id = parsed["id"].as_u64().unwrap_or(0);
+        return Ok(Some(build_public_test_request(id)));
+    }
+
+    Ok(None)
 }
 
 pub fn parse_ticker_notification(text: &str) -> Result<Option<Ticker>> {
@@ -348,6 +406,12 @@ pub fn parse_orderbook_notification(
     };
 
     Ok(Some(orderbook))
+}
+
+pub fn reset_local_orderbook_on_reconnect(local_book: &mut LocalOrderBook) {
+    local_book.last_sequence = None;
+    local_book.bids.clear();
+    local_book.asks.clear();
 }
 
 fn parse_orderbook_levels(value: &Value) -> Vec<(f64, f64)> {

--- a/crates/connector-deribit/tests/deribit_connector.rs
+++ b/crates/connector-deribit/tests/deribit_connector.rs
@@ -1,7 +1,8 @@
 use connector_deribit::{
-    backoff_delay_ms, build_subscribe_request, channel_names, extract_order_id,
-    parse_auth_response, parse_orderbook_notification, parse_ticker_notification, DeribitWsClient,
-    LocalOrderBook,
+    backoff_delay_ms, build_set_heartbeat_request, build_subscribe_request, channel_names,
+    extract_order_id, heartbeat_reply_if_requested, parse_auth_response,
+    parse_orderbook_notification, parse_ticker_notification, reset_local_orderbook_on_reconnect,
+    DeribitWsClient, LocalOrderBook,
 };
 
 #[test]
@@ -37,6 +38,13 @@ fn builds_public_subscribe_rpc_request() {
     let payload = build_subscribe_request(7, &channels);
     assert_eq!(payload["id"].as_u64(), Some(7));
     assert_eq!(payload["method"].as_str(), Some("public/subscribe"));
+}
+
+#[test]
+fn builds_set_heartbeat_request() {
+    let payload = build_set_heartbeat_request(9, 60);
+    assert_eq!(payload["method"].as_str(), Some("public/set_heartbeat"));
+    assert_eq!(payload["params"]["interval"].as_u64(), Some(60));
 }
 
 #[test]
@@ -110,6 +118,33 @@ fn parses_orderbook_snapshot_then_delta() {
 
     assert_eq!(book1.bids[0].price, 123.0);
     assert_eq!(book2.bids[0].size, 3.0);
+}
+
+#[test]
+fn responds_to_deribit_test_request_heartbeat() {
+    let incoming = r#"{
+      "jsonrpc": "2.0",
+      "id": 13,
+      "method": "heartbeat",
+      "params": {"type": "test_request"}
+    }"#;
+
+    let reply = heartbeat_reply_if_requested(incoming)
+        .expect("parsing should succeed")
+        .expect("heartbeat should need reply");
+    assert_eq!(reply["method"].as_str(), Some("public/test"));
+}
+
+#[test]
+fn resets_local_book_on_reconnect() {
+    let mut book = LocalOrderBook::new();
+    book.apply_snapshot(3, vec![(100.0, 1.0)], vec![(101.0, 2.0)])
+        .expect("snapshot should apply");
+
+    reset_local_orderbook_on_reconnect(&mut book);
+    assert!(book.last_sequence.is_none());
+    assert!(book.bids.is_empty());
+    assert!(book.asks.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Closes #75\n\n- add Deribit heartbeat request builders and test_request reply helper\n- add reconnect+resubscribe flow with exponential backoff\n- add local orderbook reset utility for reconnect recovery\n- add unit tests for heartbeat/reconnect helper behavior